### PR TITLE
update to handle local file shares

### DIFF
--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -281,12 +281,12 @@ public class ShareMenuModule extends ReactContextBaseJavaModule implements Activ
     try {
       String[] proj = { MediaStore.MediaColumns.DATA, OpenableColumns.DISPLAY_NAME };
       cursor = context.getContentResolver().query(contentUri,  proj, null, null, null);
-      int column_index = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA);
-      int column_index2 = cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME);
+      int column_index = cursor.getColumnIndex(MediaStore.MediaColumns.DATA);
+      int column_index2 = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
       cursor.moveToFirst();
 
-      String realPath = cursor.getString(column_index);
-      if(realPath == null) {
+      String realPath = column_index != -1 ? cursor.getString(column_index) : null;
+      if(realPath == null && column_index2 != -1) {
         String fileName = cursor.getString(column_index2);
         realPath = copyContentFile(context, contentUri, fileName);
       }

--- a/ios/Modules/ShareMenuReactView.swift
+++ b/ios/Modules/ShareMenuReactView.swift
@@ -116,8 +116,29 @@ public class ShareMenuReactView: NSObject {
                     if url.absoluteString.hasPrefix("file://") {
                         let dict: NSMutableDictionary = [:]
                         dict["url"] = url.absoluteString
-                        dict["mimeType"] = self.extractMimeType(from: url)
-                        dict["thumbnail"] = nil
+                        let mimeType: String = self.extractMimeType(from: url);
+                        dict["mimeType"] = mimeType
+                        do {
+                            if mimeType.contains("video") {
+                                var thumbImage: UIImage? = self.thumbnailForVideo(url: url)
+                                if thumbImage != nil {
+                                    thumbImage = thumbImage?.resizeImage(CGFloat.init(500.0), opaque: false)
+                                    let thumbImageData:NSData = thumbImage!.jpegData(compressionQuality: 0.8)! as NSData
+                                    let thumbBase64 = thumbImageData.base64EncodedString(options: .lineLength64Characters)
+                                    dict["thumbnail"] = thumbBase64
+                                }
+                                else {
+                                    throw NSError()
+                                }
+                            }
+                            else {
+                                throw NSError()
+                            }
+                        }
+                        catch {
+                            //error
+                            dict["thumbnail"] = nil
+                        }
                         dict["Id"] = UUID().uuidString
                         
                         results.add(dict)

--- a/ios/Modules/ShareMenuReactView.swift
+++ b/ios/Modules/ShareMenuReactView.swift
@@ -111,6 +111,19 @@ public class ShareMenuReactView: NSObject {
             
             if provider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
                 urlProvider = provider as? NSItemProvider
+                urlProvider.loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil) { (item, error) in
+                    let url: URL! = item as? URL
+                    if url.absoluteString.hasPrefix("file://") {
+                        let dict: NSMutableDictionary = [:]
+                        dict["url"] = url.absoluteString
+                        dict["mimeType"] = self.extractMimeType(from: url)
+                        dict["thumbnail"] = nil
+                        dict["Id"] = UUID().uuidString
+                        
+                        results.add(dict)
+                        self.shareDispatchGroup.leave()
+                    }
+                }
                 //break
             } else if provider.hasItemConformingToTypeIdentifier(kUTTypeText as String) {
                 textProvider = provider as? NSItemProvider

--- a/ios/ShareViewController.swift
+++ b/ios/ShareViewController.swift
@@ -224,14 +224,14 @@ class ShareViewController: SLComposeServiceViewController {
           dict["height"] = height
         }
         else if mimeType.starts(with: "video") {
-          if let track = try? AVURLAsset(url: url).tracks(withMediaType: AVMediaType.video) {
+          if let track = try? AVURLAsset(url: filePath).tracks(withMediaType: AVMediaType.video) {
             if let size = try? track.first!.naturalSize {
               dict["width"] = size.width
               dict["height"] = size.height
             }
             
             var thumbBase64: String = ""
-            var thumbImage: UIImage? = self.thumbnailForVideo(url: url)
+            var thumbImage: UIImage? = self.thumbnailForVideo(url: filePath)
             if thumbImage != nil {
                 thumbImage = thumbImage?.resizeImage(CGFloat.init(500.0), opaque: false)
                 let thumbImageData:NSData = thumbImage!.jpegData(compressionQuality: 0.8)! as NSData

--- a/ios/ShareViewController.swift
+++ b/ios/ShareViewController.swift
@@ -202,20 +202,20 @@ class ShareViewController: SLComposeServiceViewController {
         dict["mimeType"] = mimeType
 
         if mimeType.starts(with: "image") {
-          guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil)
+          guard let imageSource = CGImageSourceCreateWithURL(filePath as CFURL, nil)
                   , let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [AnyHashable: Any]
                   , let pixelWidth = imageProperties[kCGImagePropertyPixelWidth as String]
                   , let pixelHeight = imageProperties[kCGImagePropertyPixelHeight as String]
-                  , let orientationNumber = imageProperties[kCGImagePropertyOrientation as String]
                   else {
                     self.exit(withError: "Image Property Error")
                     return
                   }
           var width: CGFloat = 0, height: CGFloat = 0, orientation: Int = 0
-
+          if let orientationNumber = imageProperties[kCGImagePropertyOrientation as String] {
+            CFNumberGetValue(orientationNumber as! CFNumber, .intType, &orientation)
+          }
           CFNumberGetValue(pixelWidth as! CFNumber, .cgFloatType, &width)
           CFNumberGetValue(pixelHeight as! CFNumber, .cgFloatType, &height)
-          CFNumberGetValue(orientationNumber as! CFNumber, .intType, &orientation)
 
           // Check orientation and flip size if required
           if orientation > 4 { let temp = width; width = height; height = temp }


### PR DESCRIPTION
Work in progress...

iOS
- handle local file URLs passed to the component
- sometimes orientation isn't available - cater for this
- use the copied file URL as a basis to get properties of image/video

Android
- Fixed error when getting 'real url' from file(s) sent from app like Lightroom. Property processing was throwing on error if one item was missing. Now we drill down through them before failing gracefully.